### PR TITLE
Update source.less to fix issue #3

### DIFF
--- a/src/source.less
+++ b/src/source.less
@@ -464,9 +464,11 @@ div.log {
 	div.row {
 
 		// author block
-		span.authorWrap {
-			margin-right: 3px;
-		
+		span {
+			&.authorWrap {
+				margin-right: 3px;
+			}
+			
 			a.author {
 				color: @color-purple;
 				transition: 0.2s;
@@ -486,7 +488,7 @@ div.log {
 		&.self {
 			background: #2a2a2a;
 
-			span.authorWrap a.author {
+			span a.author {
 				color: @color-teal;
 				/*[[nick_color]]*/
 


### PR DESCRIPTION
The use of span.authorWrap around a.author was causing the default IRCCloud styling to take precendence. Moving the style to be span a.author correctly overrides the IRCCloud styling. Works with self messages, colourised nicknames on/off.

Only had a chance to confirm that it works with Chrome Stylish since that's all I use for IRCCloud. You may want to confirm it works fine for Firefox as well, though I don't see why the style change wouldn't be accepted by Firefox.
