### PR TITLE
IRCCloud logo pushed outside of top of page.

### DIFF
--- a/src/source.less
+++ b/src/source.less
@@ -316,7 +316,7 @@ body.app {
 body.app {
 	// page title
 	h1#title {
-		margin-top: 0;
+		margin-top: 10px;
 	}
 	h1#title span.logotype {
 		color: #eee;


### PR DESCRIPTION
Having the header margin at 0 was pushing the logo outside of the top of the screen. Changing it to 10px aligns the logo to sit vertically in the middle of the header section.
![screenshot_022515_042855_pm](https://cloud.githubusercontent.com/assets/6538746/6383068/659e2942-bd0b-11e4-92cc-1b0417b6f745.jpg)

![screenshot_022515_042936_pm](https://cloud.githubusercontent.com/assets/6538746/6383096/7da765b2-bd0b-11e4-8632-1a1f457b3f63.jpg)
